### PR TITLE
Automatic Add Round Nodes with Testing

### DIFF
--- a/BitFlow/Eval/AbstractEval.py
+++ b/BitFlow/Eval/AbstractEval.py
@@ -1,6 +1,6 @@
 from DagVisitor import Visitor
 from abc import abstractmethod
-from ..node import Dag, DagNode, Input, Constant, Add, Mul, Select, Output
+from ..node import Dag, DagNode, Input, Constant, Add, Mul, Select, Output, Round
 
 class AbstractEval(Visitor):
     def __init__(self, dag: Dag):
@@ -26,6 +26,7 @@ class AbstractEval(Visitor):
         eval_name = f"eval_{node.kind()[0]}"
         assert hasattr(self, eval_name)
         node_val = getattr(self, eval_name)(*child_values, node=node)
+
         assert node_val is not None
         self.node_values[node] = node_val
 

--- a/BitFlow/Eval/TorchEval.py
+++ b/BitFlow/Eval/TorchEval.py
@@ -1,6 +1,6 @@
 from .AbstractEval import AbstractEval
 from ..node import DagNode
-from .torch.functions import IntRound
+from ..torch.functions import IntRound
 import torch as t
 
 class TorchEval(AbstractEval):
@@ -19,3 +19,6 @@ class TorchEval(AbstractEval):
     def eval_Round(self, a, prec, node: DagNode):
         scale = 2.0**prec
         return IntRound(a * scale) / scale
+
+    def eval_Select(self, a, node: DagNode):
+        return a[node.index]

--- a/BitFlow/node.py
+++ b/BitFlow/node.py
@@ -89,7 +89,7 @@ class Round(DagNode):
     def __init__(self, val: DagNode, prec: DagNode, name=None):
         if name is None:
             name = f"{val.name}_round_{prec.name}"
-        super.__init__(self, val, prec)
+        super().__init__(name, val, prec)
 
 
 class Dag(AbstractDag):

--- a/tests/test_autoRound.py
+++ b/tests/test_autoRound.py
@@ -1,0 +1,328 @@
+import torch
+
+from BitFlow.node import Input, Constant, Dag, Add, Sub, Mul, Round, DagNode, Select, Output
+from BitFlow.IA import Interval
+from BitFlow.Eval.TorchEval import TorchEval
+from tests.test_fig3 import AddRoundNodes
+from tests.test_fig3 import NodePrinter1
+from BitFlow.casestudies.caseStudies import caseStudy
+from BitFlow.Eval import IAEval, NumEval
+
+def update_dag(dag):
+    """ TODO: Adds Round Nodes, Weight Input Nodes (grad allowed) and Output Precision Nodes (grad not allowed)
+    Args:
+        dag: Input dag
+    Returns:
+        updated dag: A dag with round nodes on each dag node which BitFlow can be run on
+    """
+
+    W = Input(name="W")
+    O = Input(name="O")
+
+    # print("DAG before Round Nodes added:")
+    # printer = NodePrinter1()
+    # printer.run(dag)
+
+    addedRoundNode = AddRoundNodes(W, O)
+    newDag = addedRoundNode.doit(dag)
+
+    # print("DAG after Round Nodes added:")
+    # printer.run(newDag)
+
+    return newDag
+
+
+def gen_fig3():
+    #(a*b) + 4 - b
+    a = Input(name="a")
+    b = Input(name="b")
+    c = Constant(4, name="c")
+    d = Mul(a, b, name="d")
+    e = Add(d, c, name="e")
+    z = Sub(e, b, name="z")
+
+    fig3_dag = Dag(outputs=[z], inputs=[a,b])
+    return fig3_dag
+
+def gen_ex1():
+    #(a * b) + (b * c)
+    a = Input(name="a")
+    b = Input(name="b")
+    c = Input(name="c")
+    d = Mul(a, b, name="d")
+    e = Mul(b, c, name="e")
+    z = Add(e, d, name="z")
+
+    dag = Dag(outputs=[z], inputs=[a, b, c])
+    return dag
+
+def test_fig3():
+    print("###############TEST FIG3###############")
+
+    fig3 = gen_fig3()
+
+    W = torch.tensor([20., 20., 20., 20., 20.])
+    O = torch.tensor([20.])
+    a, b = 10.45454524545452, 10.2323223232
+
+    print("EVAL Before Rounding")
+    evaluator = TorchEval(fig3)
+    res = evaluator.eval(a=a, b=b)
+    print("y value with full precision")
+    print(res)
+
+    newDag = update_dag(fig3)
+
+    W1 = torch.tensor([20., 20., 20., 20., 20.])
+    O1 = torch.tensor([20])
+    a1, b1 = 10.45454524545452, 10.2323223232
+
+    print("EVAL After Rounding")
+    inputs1 = {"a":a1,"b":b1,"W": W1, "O": O1}
+
+    evaluator1 = TorchEval(newDag)
+
+    y_val = evaluator1.eval(**inputs1)
+
+    print("y value with rounded precision")
+    print(y_val)
+
+    return
+
+def test_ex1():
+    print("###############TEST EX1###############")
+    fig3 = gen_ex1()
+
+    W = torch.tensor([20., 20., 20., 20., 20.])
+    O = torch.tensor([20.])
+    a, b, c = 10.45454524545452, 10.2323223232, 8.231343
+
+    print("EVAL Before Rounding")
+    evaluator = TorchEval(fig3)
+    res = evaluator.eval(a=a, b=b, c=c)
+    print("y value with full precision")
+    print(res)
+
+    newDag = update_dag(fig3)
+
+    W1 = torch.tensor([20., 20., 20., 20., 20.])
+    O1 = torch.tensor([20])
+    a1, b1, c1 = 10.45454524545452, 10.2323223232, 8.231343
+
+    print("EVAL After Rounding")
+    inputs1 = {"a":a1,"b":b1, "c":c1,"W": W1, "O": O1}
+
+    evaluator1 = TorchEval(newDag)
+
+    y_val = evaluator1.eval(**inputs1)
+
+    print("y value with rounded precision")
+    print(y_val)
+
+    return
+
+
+def test_fig3_integers():
+
+    fig3 = gen_fig3()
+    print("###############TEST FIG3 INTEGERS###############")
+
+    a, b = 3, 5
+
+    W = torch.tensor([20., 20., 20., 20., 20.])
+    O = torch.tensor([20.])
+
+    print("EVAL Before Rounding")
+    evaluator = TorchEval(fig3)
+    res = evaluator.eval(a=a, b=b)
+    print("y value with full precision")
+    print(res)
+
+    newDag = update_dag(fig3)
+
+    a1, b1 = 3, 5
+
+    W1 = torch.tensor([20., 20., 20., 20., 20.])
+    O1 = torch.tensor([20.])
+
+    print("EVAL After Rounding")
+    inputs1 = {"a": a1, "b": b1, "W": W1, "O": O1}
+
+    evaluator1 = TorchEval(newDag)
+
+    y_val = evaluator1.eval(**inputs1)
+
+    print("y value with rounded precision")
+    print(y_val)
+
+    return
+
+
+#Evaluate it in the context of Intervals
+def test_fig3_IA():
+    fig3 = gen_fig3()
+    print("###############TEST FIG3 IA###############")
+
+    a = Interval(0, 5)
+    b = Interval(3, 8)
+
+    W = torch.tensor([20., 20., 20., 20., 20.])
+    O = torch.tensor([20.])
+
+    print("EVAL Before Rounding")
+    evaluator = IAEval(fig3)
+    res = evaluator.eval(a=a, b=b)
+    print("y value with full precision")
+    print(res)
+
+    newDag = update_dag(fig3)
+
+    a1 = Interval(0, 5)
+    b1 = Interval(3, 8)
+
+    W1 = torch.tensor([20., 20., 20., 20., 20.])
+    O1 = torch.tensor([20.])
+
+    print("EVAL After Rounding")
+    inputs1 = {"a": a1, "b": b1, "W": W1, "O": O1}
+
+    evaluator1 = TorchEval(newDag)
+
+    y_val = evaluator1.eval(**inputs1)
+
+    print("y value with rounded precision")
+    print(y_val)
+
+    return
+
+
+def test_poly_approx():
+    print("###############POLY APPROX###############")
+    tmp = caseStudy
+    fig_casestudy = tmp.poly_approx()
+
+    W = torch.tensor([15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15.])
+
+    O = torch.tensor([15.])
+    a, c = torch.tensor([1., 3., -6., -10., -1.]), 3.3
+
+
+    print("EVAL Before Rounding")
+    evaluator = TorchEval(fig_casestudy)
+    res = evaluator.eval(a=a, c=c)
+    print("y value with full precision")
+    print(res)
+
+    newDag = update_dag(fig_casestudy)
+
+    #W1 = torch.tensor([2., 2., 2., 2., 2., 2., 2., 2., 2., 10., 11., 12., 13., 14.])
+
+    W1 = torch.tensor([15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15.])
+
+    O1 = torch.tensor([15.])
+    a1, c1 = torch.tensor([1., 3., -6., -10., -1.]), 3.3
+
+    print("EVAL After Rounding")
+    inputs1 = {"a": a1, "c": c1, "W": W1, "O": O1}
+    print(inputs1)
+
+    evaluator1 = TorchEval(newDag)
+
+    y_val = evaluator1.eval(**inputs1)
+
+    print("y value with rounded precision")
+    print(y_val)
+
+    return
+
+def test_RGB_to_YCbCr():
+    print("###############RGB to YCbCr###############")
+    tmp = caseStudy
+    fig_casestudy = tmp.RGB_to_YCbCr()
+
+    W = torch.tensor(
+        [15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15.])
+
+
+    O = torch.tensor([15.,15.,15.])
+    a = torch.tensor([22., 103., 200.])
+
+    print("EVAL Before Rounding")
+    evaluator = TorchEval(fig_casestudy)
+    res = evaluator.eval(a=a)
+    print("y value with full precision")
+    print(res)
+
+    newDag = update_dag(fig_casestudy)
+
+    W1 = torch.tensor(
+        [15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15.,
+         15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15.])
+
+    O1 = torch.tensor([15., 15., 15.])
+    a1 = torch.tensor([22., 103., 200.])
+
+
+    print("EVAL After Rounding")
+    inputs1 = {"a": a1, "W": W1, "O": O1}
+    print(inputs1)
+
+    evaluator1 = TorchEval(newDag)
+
+    y_val = evaluator1.eval(**inputs1)
+
+    print("y value with rounded precision")
+    print(y_val)
+
+    return
+
+def test_Matrix_Multiplication():
+    print("###############Matrix Multiplication###############")
+    tmp = caseStudy
+    fig_casestudy = tmp.Matrix_Multiplication()
+
+    W = torch.tensor(
+        [15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15.,
+         15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15.,
+         15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15.])
+
+    O = torch.tensor([15.,15.,15.,15.])
+    a = torch.tensor([[1.1, 2.2], [3, 4]])
+    b = torch.tensor([[5, 6], [7, 8]])
+
+
+    print("EVAL Before Rounding")
+    evaluator = TorchEval(fig_casestudy)
+    res = evaluator.eval(a=a,b=b)
+    print("y value with full precision")
+    print(res)
+
+    newDag = update_dag(fig_casestudy)
+
+    W1 = torch.tensor(
+        [1., 1., 1., 1., 1., 1., 1., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15.,15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15.,15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15.,15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15., 15.])
+
+    O1 = torch.tensor([1., 1., 1., 1.])
+    a1 = torch.tensor([[1.1, 2.2], [3, 4]])
+    b1 = torch.tensor([[5, 6], [7, 8]])
+
+
+    print("EVAL After Rounding")
+    inputs1 = {"a": a1, "b": b1, "W": W1, "O": O1}
+    print(inputs1)
+
+    evaluator1 = TorchEval(newDag)
+
+    y_val = evaluator1.eval(**inputs1)
+
+    print("y value with rounded precision")
+    print(y_val)
+
+    return
+
+test_fig3()
+test_ex1()
+test_fig3_integers()
+test_poly_approx()
+test_RGB_to_YCbCr()
+test_Matrix_Multiplication()

--- a/tests/test_autoRound.py
+++ b/tests/test_autoRound.py
@@ -157,45 +157,6 @@ def test_fig3_integers():
 
     return
 
-
-#Evaluate it in the context of Intervals
-def test_fig3_IA():
-    fig3 = gen_fig3()
-    print("###############TEST FIG3 IA###############")
-
-    a = Interval(0, 5)
-    b = Interval(3, 8)
-
-    W = torch.tensor([20., 20., 20., 20., 20.])
-    O = torch.tensor([20.])
-
-    print("EVAL Before Rounding")
-    evaluator = IAEval(fig3)
-    res = evaluator.eval(a=a, b=b)
-    print("y value with full precision")
-    print(res)
-
-    newDag = update_dag(fig3)
-
-    a1 = Interval(0, 5)
-    b1 = Interval(3, 8)
-
-    W1 = torch.tensor([20., 20., 20., 20., 20.])
-    O1 = torch.tensor([20.])
-
-    print("EVAL After Rounding")
-    inputs1 = {"a": a1, "b": b1, "W": W1, "O": O1}
-
-    evaluator1 = TorchEval(newDag)
-
-    y_val = evaluator1.eval(**inputs1)
-
-    print("y value with rounded precision")
-    print(y_val)
-
-    return
-
-
 def test_poly_approx():
     print("###############POLY APPROX###############")
     tmp = caseStudy

--- a/tests/test_fig3.py
+++ b/tests/test_fig3.py
@@ -1,7 +1,7 @@
-from BitFlow.node import Input, Constant, Dag, Add, Sub, Mul, DagNode
-from DagVisitor import Visitor
+from BitFlow.node import Input, Constant, Dag, Add, Sub, Mul, DagNode, Round, Output, Select
+from DagVisitor import Visitor, Transformer, AbstractDag
 from BitFlow.IA import Interval
-from BitFlow.Eval import IAEval, NumEval
+from BitFlow.Eval import IAEval, NumEval, AbstractEval
 import torch
 
 def gen_fig3():
@@ -38,6 +38,19 @@ def test_fig3_IA():
     gold = Interval(-4, 41)
     assert res == gold
 
+
+
+#Evaluate it in the context of Torch
+def test_fig3_IA():
+    fig3 = gen_fig3()
+    evaluator = IAEval(fig3)
+
+    a = torch.Tensor([3])
+    b = torch.Tensor([5])
+    res = evaluator.eval(a=a, b=b)
+    gold = torch.Tensor([14])
+    assert res == gold
+
 class NodePrinter(Visitor):
     def __init__(self, node_values):
         self.node_values = node_values
@@ -55,10 +68,22 @@ class NodePrinter(Visitor):
         #I now have access to the node and anything I initialized this class with
         print(f"Input Node {node} has a value of {self.node_values[node]}")
 
+    def test_print(self):
+        fig3 = gen_fig3()
+        evaluator = NumEval(fig3)
+
+        a, b = 3, 5
+        evaluator.eval(a=a, b=b)
+        node_values = evaluator.node_values
+        node_printer = NodePrinter(node_values)
+
+        # Visitor classes have a method called 'run' that takes in a dag and runs all the
+        # visit methods on each node
+        node_printer.run(fig3)
 
     #Generic visitor method for a node
-    #This method will be run on each node unless 
-    # a visit_<NodeType> method is defined 
+    #This method will be run on each node unless
+    # a visit_<NodeType> method is defined
     def generic_visit(self, node: DagNode):
         #Call this to visit node's children first
         Visitor.generic_visit(self, node)
@@ -77,27 +102,74 @@ class NodePrinter(Visitor):
             print(f"  {child_node}:  {self.node_values[child_node]}")
 
 
-def test_print():
-    fig3 = gen_fig3()
-    evaluator = NumEval(fig3)
 
-    a, b = 3, 5
-    evaluator.eval(a=a, b=b)
-    node_values = evaluator.node_values
-    node_printer = NodePrinter(node_values)
 
-    # Visitor classes have a method called 'run' that takes in a dag and runs all the 
-    # visit methods on each node
-    node_printer.run(fig3)
+class AddRoundNodes(Transformer):
 
-#Evaluate it in the context of Torch
-def test_fig3_IA():
-    fig3 = gen_fig3()
-    evaluator = IAEval(fig3)
+    def __init__(self, W, O):
+        self.W = W
+        #self.X = X
+        self.O = O
+        self.round_count = 0
+        self.input_count = 0
+        self.output_count = 0
+        self.rounded_outputs = []
+        self.allroots = []
 
-    a = torch.Tensor([3])
-    b = torch.Tensor([5])
-    res = evaluator.eval(a=a, b=b)
-    gold = torch.Tensor([14])
-    assert res == gold
+    def doit(self, dag: Dag): #takes a Dag and returns new Dag with round nodes added in
+
+        new_inputs = dag.inputs
+
+        self.allroots=list(dag.roots())
+        self.run(dag)
+
+        new_inputs.append(self.W)
+        #new_inputs.append(self.X)
+        new_inputs.append(self.O)
+
+        new_outputs = list(self.rounded_outputs)
+
+        return Dag(outputs=new_outputs, inputs=new_inputs)  # return dag that has taken precision as an input
+
+    def generic_visit(self, node: DagNode):
+
+        if isinstance(node, Output):
+            return None
+
+        Transformer.generic_visit(self, node) #make sure code run on all children nodes first
+
+        for child in node.children():
+            assert isinstance(child, Round)
+
+        if isinstance(node, Input):
+            returnNode = Round(node, Select(self.W, self.round_count),name=node.name + "_round")  # current node + need to get prec_input
+            self.input_count += 1
+
+        else:
+            if(node in self.allroots):
+
+                returnNode = Round(node, Select(self.O, self.output_count),
+                                   name=node.name + "_round")
+                self.rounded_outputs.append(returnNode)
+                self.output_count += 1
+
+            else:
+                returnNode = Round(node, Select(self.W, self.round_count),
+                                   name=node.name + "_round_W")
+        self.round_count += 1
+        return returnNode
+
+
+class NodePrinter1(Visitor):
+
+    # a visit_<NodeType> method is defined
+    def generic_visit(self, node: DagNode):
+        #Call this to visit node's children first
+        Visitor.generic_visit(self, node)
+
+        print(f"{node}: {type(node)}")
+        for child_node in node.children():
+            print(f"  {child_node}")
+
+
 


### PR DESCRIPTION
AddRoundNode class is complete and automatically adds a round node after each node of the input Dag. In test_autoRound, it was implemented and tested on fig3, ex1, and all case studies across various precision weights. It's ready to be implemented for use in Bitflow.